### PR TITLE
Add workflow to build container image on release

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -1,0 +1,57 @@
+name: Build Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (leave empty for latest)'
+        required: false
+        default: ''
+
+permissions:
+  packages: write
+  contents: write
+
+jobs:
+  build_endorser:
+    name: 'Build Endorser'
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'openwallet-foundation'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare docker tags for image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/endorser
+          tags: |
+            type=raw,value=${{ github.event.inputs.tag }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+
+      - name: Build and push image
+        id: builder
+        uses: docker/build-push-action@v6
+        with:
+          context: ./
+          file: ./endorser/Dockerfile.endorser
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Create workflow to build endorser container image on release. Pushes to ghcr.io