### PR TITLE
Endorse attrib transactions when DID is in allow-list

### DIFF
--- a/endorser/api/services/auto_state_handlers.py
+++ b/endorser/api/services/auto_state_handlers.py
@@ -320,6 +320,12 @@ async def is_endorsable_transaction(
                     ),
                 )
 
+            case EndorseTransactionType.attrib:
+                logger.debug(
+                    f">>> from is_endorsable_transaction: {trans} was an attrib request"
+                )
+                return True
+
         return False
 
 


### PR DESCRIPTION
A check allowing `attrib` transactions to get endorsed when the did has been published was missing, this makes it so that`attrib` transactions will be automatically endorsed for DIDs in the allow list.